### PR TITLE
Fix flicker of cluster annotations

### DIFF
--- a/Sources/Annotation.swift
+++ b/Sources/Annotation.swift
@@ -19,6 +19,26 @@ open class ClusterAnnotation: Annotation {
     open var annotations = [MKAnnotation]()
 }
 
+extension ClusterAnnotation {
+    open override var hashValue: Int {
+        return annotations.reduce(0) { (partialHashValue, annotation) -> Int in
+            partialHashValue ^ annotation.hash
+        }
+    }
+    override open func isEqual(_ object: Any?) -> Bool {
+        guard let object = object as? ClusterAnnotation else {
+            return false
+        }
+        guard annotations.count == object.annotations.count else {
+            return false
+        }
+        let inequalAnnotationPair = zip(annotations, object.annotations).first(where: { annotation1, annotation2 in
+            return annotation1.coordinate != annotation2.coordinate
+        })
+        return inequalAnnotationPair == nil
+    }
+}
+
 public enum ClusterAnnotationType {
     case color(UIColor, radius: CGFloat)
     case image(UIImage?)

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -164,22 +164,14 @@ open class ClusterManager {
         }
         
         if operation.isCancelled { return (toAdd: [], toRemove: []) }
-        
-        let before = NSMutableSet(array: mapView.annotations)
-        before.remove(mapView.userLocation)
-        
-        let after = NSSet(array: clusteredAnnotations)
-        
-        let toKeep = NSMutableSet(set: before)
-        toKeep.intersect(after as Set<NSObject>)
-        
-        let toAdd = NSMutableSet(set: after)
-        toAdd.minus(toKeep as Set<NSObject>)
-        
-        let toRemove = NSMutableSet(set: before)
-        toRemove.minus(after as Set<NSObject>)
-        
-        return (toAdd: toAdd.allObjects as? [MKAnnotation] ?? [], toRemove: toRemove.allObjects as? [MKAnnotation] ?? [])
+
+        let before = Set<NSObject>(mapView.annotations as! Array<NSObject>)
+        let after = Set<NSObject>(clusteredAnnotations as! Array<NSObject>)
+
+        let toRemove = before.subtracting(after)
+        let toAdd = after.subtracting(before)
+
+        return (toAdd: Array(toAdd) as! Array<MKAnnotation>, toRemove: Array(toRemove) as! Array<MKAnnotation>)
     }
     
 }


### PR DESCRIPTION
Close #30

The issue was that we recreate `ClusterAnnotation` on each reload (thus also when panning). And `NSMutableSet` considers two instances of `NSObject` subclass to be different.