### PR TITLE
Ambiguous Subscript Error Fix

### DIFF
--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -144,7 +144,7 @@ open class ClusterManager {
                     totalLatitude += node.coordinate.latitude
                     totalLongitude += node.coordinate.longitude
                     annotations.append(node)
-                    hash[node.coordinate, default: [MKAnnotation]()] += [node]
+                    hash[node.coordinate, defaultValue: [MKAnnotation]()] += [node]
                 }
                 
                 for value in hash.values {

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -85,7 +85,7 @@ extension CLLocationCoordinate2D {
 }
 
 extension Dictionary {
-    subscript(key: Key, `default` value: Value) -> Value {
+    subscript(key: Key, `defaultValue` value: Value) -> Value {
         mutating get { return self[key] ?? { self[key] = value; return value }() }
         set { self[key] = newValue }
     }


### PR DESCRIPTION
Hello,

When installing Cluster on a project that I am working on and complied, I received this complier error that was caused by Cluster:
<img width="981" alt="screen shot 2017-08-29 at 12 22 53 pm" src="https://user-images.githubusercontent.com/16155920/29833881-eec9493c-8cba-11e7-96d3-c7a074ff0c4a.png">
After forking the repo and investigating, I was able to correct the issue and compile Cluster with no issues. The cause of the issue was with the custom subscript that was created for `Dictionary`. I basically changed the name in the subscript `default` to `defaultValue` since `default` is technically a keyword in the Swift language. In terms of the parameter name, I am not sure if you would like to change it to something else. Let me know and I'll happily change it. Hopefully, this can be merged and others using this library won't have issues compiling. 

Thanks
😀
