### PR TITLE
Use === to compare annotations

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -94,7 +94,7 @@ extension CLLocationCoordinate2D {
 
 extension Array where Element: MKAnnotation {
     func subtracted(_ other: [Element]) -> [Element] {
-        return filter { item in !other.contains { type(of: $0) == type(of: item) && $0.coordinate == item.coordinate } }
+        return filter { item in !other.contains { $0 === item } }
     }
     mutating func subtract(_ other: [Element]) {
         self = self.subtracted(other)


### PR DESCRIPTION
Use === to compare annotations instead. This prevents other annotations with the same coordinate from being removed and fixes the issue with the incorrect number of annotations from being displayed on the map.