### PR TITLE
Use isEqual to compare annotations instead

### DIFF
--- a/Sources/Annotation.swift
+++ b/Sources/Annotation.swift
@@ -14,6 +14,27 @@ open class Annotation: MKPointAnnotation {
 
 open class ClusterAnnotation: Annotation {
     open var annotations = [MKAnnotation]()
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let object = object as? ClusterAnnotation else { return false }
+
+        if self === object {
+            return true
+        }
+
+        if coordinate != object.coordinate {
+            return false
+        }
+
+        let rhsAnnotations = object.annotations
+
+        if annotations.count != rhsAnnotations.count {
+            return false
+        }
+
+        return annotations.subtracted(rhsAnnotations).count == 0
+    }
+
 }
 
 /**

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -94,7 +94,7 @@ extension CLLocationCoordinate2D {
 
 extension Array where Element: MKAnnotation {
     func subtracted(_ other: [Element]) -> [Element] {
-        return filter { item in !other.contains { $0 === item } }
+        return filter { item in !other.contains { $0.isEqual(item) } }
     }
     mutating func subtract(_ other: [Element]) {
         self = self.subtracted(other)


### PR DESCRIPTION
The previous equality (===) check is not sufficient for ClusterAnnotation, as ClusterManager may generate a new ClusterAnnotation with the same coordinate and annotations that is currently on the map.

This PR will prevent unnecessary removing/adding of the same ClusterAnnotations that could cause flickering on the map.