### PR TITLE
Fix for missing annotations when reloading after removing/adding annotations

### DIFF
--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -141,6 +141,9 @@ open class ClusterManager {
      */
     open func removeAll() {
         tree = QuadTree(rect: MKMapRectWorld)
+
+        // Empty visible annotations array so future changes are detected correctly when reloading
+        visibleAnnotations.removeAll()
     }
     
     /**


### PR DESCRIPTION
…load

<!-- Thanks for contributing to _Cluster_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
When using this framework I noticed annotations being added to ClusterManager that did not appear on the map. This was due to calling removeAll() then add(_), then reload(_), where some of the annotations are the same. The problem is due to change detection done in clusteredAnnotations(_) based on visibleAnnotations which still has references to old annotations.

### Description
This change just clears the visibleAnnotations array when removing all annotations. It may make sense to also update visibleAnnotations in remove(_ annotation: MKAnnotation), but that is not included in this PR.
