### PR TITLE
Fix crash on iOS 10 if zoomScale is NaN

### DIFF
--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -190,7 +190,7 @@ open class ClusterManager {
     open func clusteredAnnotations(zoomScale: Double, visibleMapRect: MKMapRect, operation: Operation? = nil) -> (toAdd: [MKAnnotation], toRemove: [MKAnnotation]) {
         var isCancelled: Bool { return operation?.isCancelled ?? false }
         
-        guard !zoomScale.isInfinite else { return (toAdd: [], toRemove: []) }
+        guard !zoomScale.isInfinite, !zoomScale.isNaN else { return (toAdd: [], toRemove: []) }
         
         zoomLevel = zoomScale.zoomLevel
         let scaleFactor = zoomScale / (cellSize ?? zoomScale.cellSize)


### PR DESCRIPTION
On iOS 10 zoomScale can be NaN (for example, when calling `reloadAnnotations()` when no annotations are yet added, or before the map has been initialised completely). This leads to a crash on the division. Since there is already a check for infinity I also added a check for NaN.