### PR TITLE
Add distanceFromContestedLocation property to customize the distance …

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ var maxZoomLevel: Double // The maximum zoom level before disabling clustering.
 var minCountForClustering: Int // The minimum number of annotations for a cluster. The default is `2`.
 var shouldRemoveInvisibleAnnotations: Bool // Whether to remove invisible annotations. The default is `true`.
 var shouldDistributeAnnotationsOnSameCoordinate: Bool // Whether to arrange annotations in a circle if they have the same coordinate. The default is `true`.
+var distanceFromContestedLocation: Double // The distance in meters from contested location when the annotations have the same coordinate. The default is `3`.
 var clusterPosition: ClusterPosition // The position of the cluster annotation. The default is `.nearCenter`.
 ```
 

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -79,7 +79,7 @@ open class ClusterManager {
      The default is true.
      */
     open var shouldDistributeAnnotationsOnSameCoordinate: Bool = true
-
+    
     /**
      The distance in meters from contested location when the annotations have the same coordinate.
 

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -79,13 +79,13 @@ open class ClusterManager {
      The default is true.
      */
     open var shouldDistributeAnnotationsOnSameCoordinate: Bool = true
-	
-	/**
-	 The distance in meters from contested location when the annotations have the same coordinate.
 
-	 The default is 3.
-	 */
-	open var distanceFromContestedLocation: Double = 3
+    /**
+     The distance in meters from contested location when the annotations have the same coordinate.
+
+     The default is 3.
+    */
+    open var distanceFromContestedLocation: Double = 3
 
     /**
      The position of the cluster annotation.

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -79,13 +79,13 @@ open class ClusterManager {
      The default is true.
      */
     open var shouldDistributeAnnotationsOnSameCoordinate: Bool = true
-
-	  /**
-	  The distance in meters from contested location when the annotations have the same coordinate.
-
-  	The default is 3.
-	  */
-	  open var distanceFromContestedLocation: Double = 3
+	
+	/**
+	 The distance in meters from contested location when the annotations have the same coordinate.
+	
+	 The default is 3.
+	 */
+	open var distanceFromContestedLocation: Double = 3
 
     /**
      The position of the cluster annotation.

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -82,7 +82,7 @@ open class ClusterManager {
 	
 	/**
 	 The distance in meters from contested location when the annotations have the same coordinate.
-	
+
 	 The default is 3.
 	 */
 	open var distanceFromContestedLocation: Double = 3

--- a/Sources/Cluster.swift
+++ b/Sources/Cluster.swift
@@ -79,7 +79,14 @@ open class ClusterManager {
      The default is true.
      */
     open var shouldDistributeAnnotationsOnSameCoordinate: Bool = true
-    
+
+	  /**
+	  The distance in meters from contested location when the annotations have the same coordinate.
+
+  	The default is 3.
+	  */
+	  open var distanceFromContestedLocation: Double = 3
+
     /**
      The position of the cluster annotation.
      */
@@ -323,10 +330,9 @@ open class ClusterManager {
             for value in hash.values where value.count > 1 {
                 for (index, annotation) in value.enumerated() {
                     tree.remove(annotation)
-                    let distanceFromContestedLocation = 3 * Double(value.count) / 2
                     let radiansBetweenAnnotations = (.pi * 2) / Double(value.count)
                     let bearing = radiansBetweenAnnotations * Double(index)
-                    (annotation as? MKPointAnnotation)?.coordinate = annotation.coordinate.coordinate(onBearingInRadians: bearing, atDistanceInMeters: distanceFromContestedLocation)
+                    (annotation as? MKPointAnnotation)?.coordinate = annotation.coordinate.coordinate(onBearingInRadians: bearing, atDistanceInMeters: self.distanceFromContestedLocation)
                     tree.add(annotation)
                 }
             }


### PR DESCRIPTION
…between annotations when they have the same coordinate.

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It gives the possibility to users to customize the distance of the contested location for annotations that have the same coordinate.

Feature Request: https://github.com/efremidze/Cluster/issues/115

### Description
<!--- Describe your changes in detail. -->
- Add `distanceFromContestedLocation` property
- Send it directly:
```
(annotation as? MKPointAnnotation)?.coordinate = annotation.coordinate.coordinate(onBearingInRadians: bearing, atDistanceInMeters: self.distanceFromContestedLocation)
```