### PR TITLE
Update QuadTree.swift for faster add

### DIFF
--- a/Sources/QuadTree.swift
+++ b/Sources/QuadTree.swift
@@ -78,9 +78,12 @@ extension QuadTreeNode: AnnotationsContainer {
     func add(_ annotation: MKAnnotation) -> Bool {
         guard rect.contains(annotation.coordinate) else { return false }
         
+        if annotations.count != QuadTreeNode.maxPointCapacity {
+            annotations.append(annotation)
+        }
+            
         switch type {
         case .leaf:
-            annotations.append(annotation)
             // if the max capacity was reached, become an internal node
             if annotations.count == QuadTreeNode.maxPointCapacity {
                 subdivide()


### PR DESCRIPTION
Add point based on maxPointCapacity instead of node type for performance gain and reuse of existing internal nodes
